### PR TITLE
Improve mobile screen layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 style="background-image: url('art.jpg'); 
 background-blend-mode: darken; background-repeat: repeat-y; background-size: cover;">
 <div class="w3-container w3-center w3-theme-d2">
-  <h1>Whoop QR Code Generator</h1>
+  <h1 class="w3-hide-small">Whoop QR Code Generator</h1>
   <img src="whoop.png" class="w3-image w3-opacity-max w3-padding-16" style="width: 3rem; height: auto;">
 </div>
 
@@ -43,8 +43,8 @@ background-blend-mode: darken; background-repeat: repeat-y; background-size: cov
         <b><select class="w3-select w3-text-theme" id="fontSelection">
           <option value="24px DePixel">Pixel</option>
           <option value="24px large9">Large</option>
-          <option value="24px Verdana">Verdana</option>
-          <option value="24px Arial">Arial</option>
+          <option value="28px system-ui">System UI</option>
+          <option value="32px Verdana">Verdana</option>
         </select></b>
       </div>
 

--- a/script.js
+++ b/script.js
@@ -1,10 +1,18 @@
 document.getElementById("qrForm").addEventListener("submit", function (event) {
-  event.preventDefault();
+    event.preventDefault();
+    handleSubmit();
+  });
 
+document.getElementById("fontSelection").addEventListener("keypress", function (event) {
+  event.preventDefault();
+  if (event.key==='Enter' | event.code==='Enter') {
+    handleSubmit();
+  }
+});
+
+function handleSubmit() {
   const inputName = document.getElementById("nameInput").value;
-  const firmwareType = document.querySelector(
-    'input[name="firmware"]:checked'
-  ).value;
+  const firmwareType = document.querySelector('input[name="firmware"]:checked').value;
   const qrElement = document.getElementById("qrcode");
 
   if (inputName.trim() !== "") {
@@ -15,7 +23,7 @@ document.getElementById("qrForm").addEventListener("submit", function (event) {
     qrElement.style.display = "none";
     alert("Please enter a name!");
   }
-});
+}
 
 function showLoader() {
   const qrElement = document.getElementById("qrcode");
@@ -26,7 +34,7 @@ function showLoader() {
 function generateQRCode(inputName, firmwareType, qrElement) {
   let bgColor = "ffffff00"; // QS Transparent background
   let bgImageDataColor = 0;
-  let x = 10; //shift qr to the right for Qicksilver
+  let x = 10; //shift QR to the right for Quicksilver
   if (firmwareType === "Betaflight") {
     bgColor = "00ff00"; // BF Green background
     bgImageDataColor = 4278255360;


### PR DESCRIPTION
 - Hide H1 header on a smaller screen. It makes vertical size more compact. on a mobile.
 - QR is generated when You hit Enter after font selection.
 - Make Verdana font bigger. Replace Arial with System UI font.